### PR TITLE
hide labels starting with a '*'

### DIFF
--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -797,7 +797,7 @@ function render_sankey(allNodes, allFlows, cfg, numberStyle) {
     allNodes.filter(shadowFilter)
       .forEach((n) => {
       // Hide labels starting with a '*'
-      if (n.name.startsWith('*')) {
+      if (n.name.startsWith('-') && n.name.endsWith('-')) {
         n.labelText = '';
       } else {
         n.labelText = cfg.labelvalue_appears

--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -796,9 +796,13 @@ function render_sankey(allNodes, allFlows, cfg, numberStyle) {
     // it used to be, but we need to know now for the sake of layout):
     allNodes.filter(shadowFilter)
       .forEach((n) => {
-      n.labelText
-        = cfg.labelvalue_appears
+      // Hide labels starting with a '*'
+      if (n.name.startsWith('*')) {
+        n.labelText = '';
+      } else {
+        n.labelText = cfg.labelvalue_appears
           ? `${n.name}: ${withUnits(n.value)}` : n.name;
+      }
       // Which side of the node will the label be on?
       const labelBefore
         = cfg.labelposition_first === 'before'

--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -720,7 +720,8 @@ function render_sankey(allNodes, allFlows, cfg, numberStyle) {
       // it's what we have for now:
       exH = measureText('x', 'ex').w,
       // Firefox has unique SVG measurements in 2022, so we look for it:
-      browserKey = isFirefox() ? 'firefox' : '*',
+      browserKey = isFirefox() ? 'firefox' : 
+    ,
       metrics
         = fontMetrics[browserKey][cfg.labels_fontface]
           || fontMetrics[browserKey]['*'],
@@ -796,7 +797,7 @@ function render_sankey(allNodes, allFlows, cfg, numberStyle) {
     // it used to be, but we need to know now for the sake of layout):
     allNodes.filter(shadowFilter)
       .forEach((n) => {
-      // Hide labels starting with a '*'
+      // Hide labels with a strike-through notation. e.g.: '-hidden label-'
       if (n.name.startsWith('-') && n.name.endsWith('-')) {
         n.labelText = '';
       } else {

--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -720,8 +720,7 @@ function render_sankey(allNodes, allFlows, cfg, numberStyle) {
       // it's what we have for now:
       exH = measureText('x', 'ex').w,
       // Firefox has unique SVG measurements in 2022, so we look for it:
-      browserKey = isFirefox() ? 'firefox' : 
-    ,
+      browserKey = isFirefox() ? 'firefox' : '*',
       metrics
         = fontMetrics[browserKey][cfg.labels_fontface]
           || fontMetrics[browserKey]['*'],


### PR DESCRIPTION
I wanted to have an unlabeled bar in the middle and solved it with hiding all labels that start with a '*'.

Example:
Wages [1500] *Budget
Other [250] *Budget

*Budget [450] Taxes
*Budget [420] Housing
*Budget [400] Food
*Budget [295] Transportation
*Budget [25] Savings
:*Budget #708090
*Budget [160] Other Necessities #0F0

![sankeymatic_20230518_095832_1200x1200](https://github.com/nowthis/sankeymatic/assets/111345544/0aa2e342-eee7-4839-ae20-605322b3526d)

