### PR TITLE
Feature: Add TSV support for easier Excel copy-paste

### DIFF
--- a/build/constants.js
+++ b/build/constants.js
@@ -72,7 +72,8 @@ const MAXBREAKPOINT = 9999,
     ['internal_iterations', ['whole', 25, [0, 50]]],
     ['internal_revealshadows', ['yn', 'n', []]],
   ]),
-
+	SYM_USE_REMAINDER = '*',
+	SYM_FILL_MISSING = '?',
   // Some reusable regular expressions to be precompiled:
   reWholeNumber = /^\d+$/,
   reHalfNumber = /^\d+(?:\.5)?$/,
@@ -122,7 +123,18 @@ labelposition scheme per_stage
 labels relativesize 100
  magnify 100
 `,
+    // The format of a row can be in one of the formats:
+    // * `<source>[<amount>]<target>[#color[.opacity]]`
+    // * `<source>  <amount>  <target>[#color[.opacity]]`
+    // where `source` and `target` are the node names
+    // `amount` is numeric or one of the symbols `*` or `?`
+    // `color` is optional in 3 or 6 character hex
+    // `opacity` is optional in decimal form
+    // e.g. 'x [...] y #99aa00' or 'x [...] y #99aa00.25'
 
+  reFlowLine =    /^\s*(?<sourceNode>.+?)\s*(?<!\\)\[\s*(?<amount>[^\]]*?)\s*(?<!\\)\]\s*(?<targetNode>.*?)\s*(?:#\s*(?<color>[a-f0-9]{3,6})?(?<opacity>\.\d{1,4})?)?\s*$/i,
+  reTSVFlowLine = /^[ ]*(?<sourceNode>.+?)[ ]*(?<!\\)\t[ ]*(?<amount>[^\t]*?)[ ]*(?<!\\)\t[ ]*(?<targetNode>.*?)\s*(?:#\s*(?<color>[a-f0-9]{3,6})?(?<opacity>\.\d{1,4})?)?\s*$/i,
+	reCleanValue = /[^\-0-9.*?]/g,
   reNodeLine = /^:(.+) #([a-f0-9]{0,6})?(\.\d{1,4})?\s*(>>|<<)*\s*(>>|<<)*$/i,
   reFlowTargetWithSuffix = /^(.+)\s+(#\S+)$/,
 

--- a/test/constantsProxy.mjs
+++ b/test/constantsProxy.mjs
@@ -1,0 +1,6 @@
+// this is a bit of a hack to allow minimal refactoring to the original code while supporting esm for the tests
+import { readFileSync } from 'node:fs';
+const constantsCode = readFileSync('./build/constants.js', { encoding: 'utf8' });
+
+const constants = await import('data:text/javascript;charset=utf-8,' +encodeURIComponent(constantsCode + '\n export default { reTSVFlowLine, reFlowLine };'));
+export const { reTSVFlowLine, reFlowLine } = constants.default;

--- a/test/flowLine.test.mjs
+++ b/test/flowLine.test.mjs
@@ -1,0 +1,166 @@
+// Test suite for TSV flow line parsing
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { reFlowLine } from './constantsProxy.mjs';
+
+/**
+ * Test a single flow line against the regex
+ * @param {string} input - The flow line to test
+ * @param {Object} expected - Expected match groups
+ * @param {string} expected.sourceNode - Expected source node
+ * @param {string} expected.amount - Expected amount
+ * @param {string} expected.targetNode - Expected target node
+ * @param {string} [expected.color] - Expected color (without #)
+ * @param {string} [expected.opacity] - Expected opacity
+ */
+function testFlowLine(input, expected) {
+  const match = input.match(reFlowLine);
+
+  if (!match) {
+    throw new Error(`Input did not match regex: ${JSON.stringify(input)}`);
+  }
+
+  const { groups } = match;
+
+  // Check required groups
+  assert.strictEqual(groups.sourceNode, expected.sourceNode, `Source node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.amount, expected.amount, `Amount mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.targetNode, expected.targetNode, `Target node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+
+  // Check optional groups
+  if ('color' in expected) {
+    assert.strictEqual(groups.color, expected.color, `Color mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.color !== "fff" ) { // `fff` special case for tests for convenience
+    assert.strictEqual(groups.color, undefined, `Unexpected color in: ${input}`);
+  }
+
+  if ('opacity' in expected) {
+    assert.strictEqual(groups.opacity, expected.opacity, `Opacity mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.opacity !== ".99") { // `99` special case for tests for convenience
+    assert.strictEqual(groups.opacity, undefined, `Unexpected opacity in: ${input}`);
+  }
+}
+
+describe('Flow Line Parser', () => {
+  it('should parse basic flow line', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target'
+    };
+    testFlowLine('Source[100]Target', expected);
+    testFlowLine(' Source [ 100 ] Target', expected);
+    testFlowLine('  Source [\t  100 \t]  Target  ', expected);
+  });
+
+  it('should parse with color', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000'
+    };
+    testFlowLine('Source[100]Target #ff0000', expected);
+    testFlowLine('  Source[100]Target #ff0000', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #ff0000  ', expected);
+  });
+
+  it('should parse with color and opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000',
+      opacity: '.75'
+    };
+    testFlowLine('Source[100]Target #ff0000.75', expected);
+    testFlowLine('  Source[100]Target #ff0000.75', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #ff0000.75  ', expected);
+  });
+
+  it('should handle 3-digit hex colors', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'f00'
+    };
+    testFlowLine('Source[100]Target #f00', expected);
+    testFlowLine('  Source[100]Target #f00', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #f00  ', expected);
+  });
+
+    it('should parse with just opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      opacity: '.75'
+    };
+    testFlowLine('Source[100]Target #.75', expected);
+    testFlowLine('  Source[100]Target #.75', expected);
+    testFlowLine('  Source  [  100  ]  Target  \t  #.75  ', expected);
+  });
+
+  it('should handle empty amount', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '',
+      targetNode: 'Target'
+    };
+    testFlowLine('Source[]Target', expected);
+    testFlowLine('  Source[]Target', expected);
+    testFlowLine('  Source  [\t  \t]Target  ', expected);
+  });
+
+  it('should handle empty target for when target and amaount are flipped', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: 'Target',
+      targetNode: ''
+    };
+    testFlowLine('Source[Target]', expected);
+    testFlowLine('Source[Target]#fff', expected);
+    testFlowLine('Source[Target]#fff.99', expected);
+    testFlowLine('  Source  [  Target  ]  #fff  ', expected);
+    testFlowLine('  Source  [  Target  ]  #fff.99  ', expected);
+  });
+
+  it('should handle opacity with 1-4 digits', () => {
+    const testCases = [
+      { input: '.1', valid: true },
+      { input: '.12', valid: true },
+      { input: '.123', valid: true },
+      { input: '.1234', valid: true },
+      { input: '.12345', valid: false },
+      { input: '1.2', valid: false }
+    ];
+
+    testCases.forEach(({ input, valid }) => {
+      const line = `Source[100]Target #${input}`;
+      const match = line.match(reFlowLine);
+
+      if (valid) {
+        assert(match, `Should match: ${line}`);
+        assert.strictEqual(match.groups.opacity, input, `Opacity should be ${input}`);
+      } else {
+        assert(!match || !match.groups.opacity, `Should not match invalid opacity: ${line}`);
+      }
+    });
+  });
+
+  it('should not match invalid color formats', () => {
+    const invalidLines = [
+      'Source[100]Target #',
+      'Source[100]Target #zzz',
+      'Source[100]Target #ff0000.',
+      'Source[100]Target #ff0000.abc',
+      'Source[100]Target #ff0000.12345'
+    ];
+
+    invalidLines.forEach(line => {
+      const match = line.match(reFlowLine);
+      assert(!match || !match.groups.color, `Should not match invalid color format: ${line}`);
+    });
+  });
+});

--- a/test/tsvFlowLine.test.mjs
+++ b/test/tsvFlowLine.test.mjs
@@ -1,0 +1,186 @@
+// Test suite for TSV flow line parsing
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { reTSVFlowLine } from './constantsProxy.mjs';
+
+/**
+ * Test a single TSV flow line against the regex
+ * @param {string} input - The TSV line to test
+ * @param {Object} expected - Expected match groups
+ * @param {string} expected.sourceNode - Expected source node
+ * @param {string} expected.amount - Expected amount
+ * @param {string} expected.targetNode - Expected target node
+ * @param {string} [expected.color] - Expected color (without #)
+ * @param {string} [expected.opacity] - Expected opacity
+ */
+function testTsvLine(input, expected) {
+  const match = input.match(reTSVFlowLine);
+
+  if (!match) {
+    throw new Error(`Input did not match regex: ${JSON.stringify(input)}`);
+  }
+
+  const { groups } = match;
+
+  // Check required groups
+  assert.strictEqual(groups.sourceNode, expected.sourceNode, `Source node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.amount, expected.amount, `Amount mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  assert.strictEqual(groups.targetNode, expected.targetNode, `Target node mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+
+  // Check optional groups
+  if ('color' in expected) {
+    assert.strictEqual(groups.color, expected.color, `Color mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.color !== "fff" ) { // `fff` special case for tests for convenience
+    assert.strictEqual(groups.color, undefined, `Unexpected color in: ${input}`);
+  }
+
+  if ('opacity' in expected) {
+    assert.strictEqual(groups.opacity, expected.opacity, `Opacity mismatch for: ${input} (groups: ${JSON.stringify(groups)})`);
+  } else if (groups.opacity !== ".99") { // `99` special case for tests for convenience
+    assert.strictEqual(groups.opacity, undefined, `Unexpected opacity in: ${input}`);
+  }
+}
+
+describe('TSV Flow Line Parser', () => {
+  it('should parse basic TSV line', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target'
+    };
+    testTsvLine('Source\t100\tTarget', expected);
+    testTsvLine(' Source \t 100 \t Target', expected);
+    testTsvLine('  Source \t  100 \t  Target  ', expected);
+  });
+
+  it('should parse basic TSV line with escaped tabs in fields', () => {
+    const expected = {
+      sourceNode: '\\tSource',
+      amount: '\\t100',
+      targetNode: '\\tTarget'
+    };
+    testTsvLine('\\tSource\t\\t100\t\\tTarget', expected);
+    testTsvLine('  \\tSource  \t  \\t100  \t  \\tTarget  ', expected);
+  });
+
+  it('should parse with color', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000'
+    };
+    testTsvLine('Source\t100\tTarget #ff0000', expected);
+    testTsvLine('  Source\t100\tTarget #ff0000', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #ff0000  ', expected);
+  });
+
+  it('should parse with color and opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'ff0000',
+      opacity: '.75'
+    };
+    testTsvLine('Source\t100\tTarget #ff0000.75', expected);
+    testTsvLine('  Source\t100\tTarget #ff0000.75', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #ff0000.75  ', expected);
+  });
+
+  it('should handle 3-digit hex colors', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      color: 'f00'
+    };
+    testTsvLine('Source\t100\tTarget #f00', expected);
+    testTsvLine('  Source\t100\tTarget #f00', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #f00  ', expected);
+  });
+
+    it('should parse with just opacity', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '100',
+      targetNode: 'Target',
+      opacity: '.75'
+    };
+    testTsvLine('Source\t100\tTarget #.75', expected);
+    testTsvLine('  Source\t100\tTarget #.75', expected);
+    testTsvLine('  Source  \t  100  \t  Target  \t  #.75  ', expected);
+  });
+
+  it('should handle empty amount', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: '',
+      targetNode: 'Target'
+    };
+    testTsvLine('Source\t\tTarget', expected);
+    testTsvLine('  Source\t\tTarget', expected);
+    testTsvLine('  Source  \t  \tTarget  ', expected);
+  });
+
+  it('should handle empty target for when target and amaount are flipped', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: 'Target',
+      targetNode: ''
+    };
+    testTsvLine('Source\tTarget\t', expected);
+    testTsvLine('Source\tTarget\t#fff', expected);
+    testTsvLine('Source\tTarget\t#fff.99', expected);
+    testTsvLine('  Source  \t  Target  \t  #fff  \t  ', expected);
+    testTsvLine('  Source  \t  Target  \t  #fff.99  \t  ', expected);
+  });
+
+  it('should handle empty target without last tab', () => {
+    const expected = {
+      sourceNode: 'Source',
+      amount: 'Target',
+      targetNode: ''
+    };
+    testTsvLine('  Source\tTarget\t', expected);
+    testTsvLine('  Source  \tTarget  \t', expected);
+  });
+
+  it('should handle opacity with 1-4 digits', () => {
+    const testCases = [
+      { input: '.1', valid: true },
+      { input: '.12', valid: true },
+      { input: '.123', valid: true },
+      { input: '.1234', valid: true },
+      { input: '.12345', valid: false },
+      { input: '1.2', valid: false }
+    ];
+
+    testCases.forEach(({ input, valid }) => {
+      const line = `Source\t100\tTarget #${input}`;
+      const match = line.match(reTSVFlowLine);
+
+      if (valid) {
+        assert(match, `Should match: ${line}`);
+        assert.strictEqual(match.groups.opacity, input, `Opacity should be ${input}`);
+      } else {
+        assert(!match || !match.groups.opacity, `Should not match invalid opacity: ${line}`);
+      }
+    });
+  });
+
+  it('should not match invalid color formats', () => {
+    const invalidLines = [
+      'Source\t100\tTarget #',
+      'Source\t100\tTarget #zzz',
+      'Source\t100\tTarget #ff0000.',
+      'Source\t100\tTarget #ff0000.abc',
+      'Source\t100\tTarget #ff0000.12345'
+    ];
+
+    invalidLines.forEach(line => {
+      const match = line.match(reTSVFlowLine);
+      assert(!match || !match.groups.color, `Should not match invalid color format: ${line}`);
+    });
+  });
+});


### PR DESCRIPTION
It's really janky to build a Sankey from Excel or Google Sheets. Ideally, we could copy-paste from three columns that have the source, target and amount columns. 

This PR adds support for tab separated definitions allowing for:
```
Wages \t 1500 \t Budget
Other \t 250 \t Budget
```

It also supports order confusion in the garget and amount columns:
```
Wages \t Budget  \t 1500
Other \t Budget \t 250
```

Additionally, it is much more lenient with the amount allowing for formatted values in a copy-paste to be gracefully handled:
* `Wages [$1,500] Budget`
* `Wages [1 500,00 €] Budget`


In an attempt to make the minimal amount of changes without wholesale refactoring, I've added tests and necessary shims for tests of the regex.

Summary of changes in the PR:
* support for TSV node definitions
* target-name and amount column confusion (swap detection)
* graceful amount detection, removing formatting
* tests for node definition regex's