### PR TITLE
Dockerfile cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ RUN echo "RedirectMatch ^/$ /build/" | tee -a /usr/local/apache2/conf/httpd.conf
 
 COPY . /usr/local/apache2/htdocs
 
+# NOTE - we only chown "logs" directory so httpd can start - the files themselves
+# are left owned by root to prevent any modificiation of the running container
 RUN adduser -u 1000 -D nonroot && \
-    chown -R 1000:1000 /usr/local/apache2
+    chown -R 1000:1000 /usr/local/apache2/logs
+    # chown -R 1000:1000 /usr/local/apache2
 
 # Indicate what port we will listen on
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
-FROM httpd:2-alpine
+FROM docker.io/library/httpd:2-alpine
 
-RUN echo "RedirectMatch ^/$ /build/" | tee -a /usr/local/apache2/conf/httpd.conf
+# Redirect root directory to the /build/; also run on high port
+RUN echo "RedirectMatch ^/$ /build/" | tee -a /usr/local/apache2/conf/httpd.conf && \
+    sed -i -e 's/^Listen 80/Listen 8000/' /usr/local/apache2/conf/httpd.conf
 
 COPY . /usr/local/apache2/htdocs
+
+RUN adduser -u 1000 -D nonroot && \
+    chown -R 1000:1000 /usr/local/apache2
+
+# Indicate what port we will listen on
+EXPOSE 8000
+
+# Run as non-root
+USER 1000
+


### PR DESCRIPTION
a/ Always use fully qualified image name

Not noticed if you're using Docker (or Docker Desktop), but the short container images are problematic for other containerization systems (most commonly will be seen by folks using podman / podman desktop).

b/ Update container to run as non-root.

Always best practice.  Giving a numeric "USER" helps in container orchestration systems to permit "runAsNonRoot".

c/ Protect container contents when running.

By limiting to only one subdirectory to chown as the non root user, we protect the container from being modified after starting, e.g. this would prevent a flaw in the code from permitting an attacker to modify the web content to their own end.
